### PR TITLE
Command/Response traits w\ DeleteObject, GenAsymmetricKey, GetObjectInfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,13 @@ keywords    = ["cryptography", "encryption", "security"]
 
 [dependencies]
 aesni = "0.2"
+bitflags = "1.0"
 block-modes = { git = "https://github.com/RustCrypto/block-ciphers.git" }
 byteorder = "1.2"
 clear_on_drop = "0.2"
 cmac = "0.1"
 constant_time_eq = "0.1"
+ed25519-dalek = { version = "= 0.6.0", optional = true, features = ["sha2"] }
 failure = "0.1"
 failure_derive = "0.1"
 hmac = "0.4"
@@ -27,4 +29,4 @@ tiny_http = { version = "0.5", optional = true }
 
 [features]
 default = []
-mockhsm = ["tiny_http"]
+mockhsm = ["ed25519-dalek", "tiny_http"]

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ The YubiHSM2 device should be in the default factory state. To reset it to this
 state, either use the [yubihsm-shell reset] command or press on the YubiHSM2 for
 10 seconds immediately after inserting it.
 
+**NOTE THAT THESE TESTS ARE DESTRUCTIVE: DO NOT RUN THEM AGAINST A YUBIHSM2
+WHICH CONTAINS KEYS YOU CARE ABOUT**
+
 [YubiHSM2 SDK]: https://developers.yubico.com/YubiHSM2/Releases/
 [yubihsm-shell reset]: https://developers.yubico.com/YubiHSM2/Commands/Reset.html
 

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -1,0 +1,209 @@
+//! Cryptographic algorithms supported by the `YubiHSM2`
+
+use failure::Error;
+
+/// Cryptographic algorithm types supported by the `YubiHSM2`
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[allow(non_camel_case_types)]
+pub enum Algorithm {
+    /// rsa-pkcs1-sha1
+    RSA_PKCS1_SHA1 = 0x01,
+
+    /// rsa-pkcs1-sha256
+    RSA_PKCS1_SHA256 = 0x02,
+
+    /// rsa-pkcs1-sha384
+    RSA_PKCS1_SHA384 = 0x03,
+
+    /// rsa-pkcs1-sha512
+    RSA_PKCS1_SHA512 = 0x04,
+
+    /// rsa-pss-sha1
+    RSA_PSS_SHA1 = 0x05,
+
+    /// rsa-pss-sha256
+    RSA_PSS_SHA256 = 0x06,
+
+    /// rsa-pss-sha384
+    RSA_PSS_SHA384 = 0x07,
+
+    /// rsa-pss-sha512
+    RSA_PSS_SHA512 = 0x08,
+
+    /// rsa2048
+    RSA2048 = 0x09,
+
+    /// rsa3072
+    RSA3072 = 0x0a,
+
+    /// rsa4096
+    RSA4096 = 0x0b,
+
+    /// ecp256 (secp256r1)
+    EC_P256 = 0x0c,
+
+    /// ecp384 (secp384r1)
+    EC_P384 = 0x0d,
+
+    /// ecp521 (secp521r1)
+    EC_P521 = 0x0e,
+
+    /// eck256 (secp256k1)
+    EC_K256 = 0x0f,
+
+    /// ecpb256 (brainpool256r1)
+    EC_BP256 = 0x10,
+
+    /// ecpb384 (brainpool384r1)
+    EC_BP384 = 0x11,
+
+    /// ecpb512 (brainpool512r1)
+    EC_BP512 = 0x12,
+
+    /// hmac-sha1
+    HMAC_SHA1 = 0x13,
+
+    /// hmac-sha256
+    HMAC_SHA256 = 0x14,
+
+    /// hmac-sha384
+    HMAC_SHA384 = 0x15,
+
+    /// hmac-sha512
+    HMAC_SHA512 = 0x16,
+
+    /// ecdsa-sha1
+    EC_ECDSA_SHA1 = 0x17,
+
+    /// ecdsa
+    EC_ECDH = 0x18,
+
+    /// rsa-oaep-sha1
+    RSA_OAEP_SHA1 = 0x19,
+
+    /// rsa-oaep-sha256
+    RSA_OAEP_SHA256 = 0x1a,
+
+    /// rsa-oaep-sha384
+    RSA_OAEP_SHA384 = 0x1b,
+
+    /// rsa-oaep-sha512
+    RSA_OAEP_SHA512 = 0x1c,
+
+    /// aes128-ccm-wrap
+    AES128_CCM_WRAP = 0x1d,
+
+    /// opaque
+    OPAQUE_DATA = 0x1e,
+
+    /// x509-cert
+    OPAQUE_X509_CERT = 0x1f,
+
+    /// mgf-sha1
+    MGF1_SHA1 = 0x20,
+
+    /// mgf-sha256
+    MGF1_SHA256 = 0x21,
+
+    /// mgf-sha384
+    MGF1_SHA384 = 0x22,
+
+    /// mgf-sha512
+    MGF1_SHA512 = 0x23,
+
+    /// template-ssh
+    TEMPL_SSH = 0x24,
+
+    /// yubico-otp-aes128
+    YUBICO_OTP_AES128 = 0x25,
+
+    /// yubico-aes-auth
+    YUBICO_AES_AUTH = 0x26,
+
+    /// yubico-otp-aes192
+    YUBICO_OTP_AES192 = 0x27,
+
+    /// yubico-otp-aes256
+    YUBICO_OTP_AES256 = 0x28,
+
+    /// aes192-ccm-wrap
+    AES192_CCM_WRAP = 0x29,
+
+    /// aes256-ccm-wrap
+    AES256_CCM_WRAP = 0x2a,
+
+    /// ecdsa-sha256
+    EC_ECDSA_SHA256 = 0x2b,
+
+    /// ecdsa-sha384
+    EC_ECDSA_SHA384 = 0x2c,
+
+    /// ecdsa-sha512
+    EC_ECDSA_SHA512 = 0x2d,
+
+    /// ed25519
+    EC_ED25519 = 0x2e,
+
+    /// ecp224 (secp224r1)
+    EC_P224 = 0x2f,
+}
+
+impl Algorithm {
+    /// Convert an unsigned byte into an Algorithm (if valid)
+    pub fn from_u8(byte: u8) -> Result<Self, Error> {
+        Ok(match byte {
+            0x01 => Algorithm::RSA_PKCS1_SHA1,
+            0x02 => Algorithm::RSA_PKCS1_SHA256,
+            0x03 => Algorithm::RSA_PKCS1_SHA384,
+            0x04 => Algorithm::RSA_PKCS1_SHA512,
+            0x05 => Algorithm::RSA_PSS_SHA1,
+            0x06 => Algorithm::RSA_PSS_SHA256,
+            0x07 => Algorithm::RSA_PSS_SHA384,
+            0x08 => Algorithm::RSA_PSS_SHA512,
+            0x09 => Algorithm::RSA2048,
+            0x0a => Algorithm::RSA3072,
+            0x0b => Algorithm::RSA4096,
+            0x0c => Algorithm::EC_P256,
+            0x0d => Algorithm::EC_P384,
+            0x0e => Algorithm::EC_P521,
+            0x0f => Algorithm::EC_K256,
+            0x10 => Algorithm::EC_BP256,
+            0x11 => Algorithm::EC_BP384,
+            0x12 => Algorithm::EC_BP512,
+            0x13 => Algorithm::HMAC_SHA1,
+            0x14 => Algorithm::HMAC_SHA256,
+            0x15 => Algorithm::HMAC_SHA384,
+            0x16 => Algorithm::HMAC_SHA512,
+            0x17 => Algorithm::EC_ECDSA_SHA1,
+            0x18 => Algorithm::EC_ECDH,
+            0x19 => Algorithm::RSA_OAEP_SHA1,
+            0x1a => Algorithm::RSA_OAEP_SHA256,
+            0x1b => Algorithm::RSA_OAEP_SHA384,
+            0x1c => Algorithm::RSA_OAEP_SHA512,
+            0x1d => Algorithm::AES128_CCM_WRAP,
+            0x1e => Algorithm::OPAQUE_DATA,
+            0x1f => Algorithm::OPAQUE_X509_CERT,
+            0x20 => Algorithm::MGF1_SHA1,
+            0x21 => Algorithm::MGF1_SHA256,
+            0x22 => Algorithm::MGF1_SHA384,
+            0x23 => Algorithm::MGF1_SHA512,
+            0x24 => Algorithm::TEMPL_SSH,
+            0x25 => Algorithm::YUBICO_OTP_AES128,
+            0x26 => Algorithm::YUBICO_AES_AUTH,
+            0x27 => Algorithm::YUBICO_OTP_AES192,
+            0x28 => Algorithm::YUBICO_OTP_AES256,
+            0x29 => Algorithm::AES192_CCM_WRAP,
+            0x2a => Algorithm::AES256_CCM_WRAP,
+            0x2b => Algorithm::EC_ECDSA_SHA256,
+            0x2c => Algorithm::EC_ECDSA_SHA384,
+            0x2d => Algorithm::EC_ECDSA_SHA512,
+            0x2e => Algorithm::EC_ED25519,
+            0x2f => Algorithm::EC_P224,
+            _ => bail!("invalid algorithm: {:?}", byte),
+        })
+    }
+    /// Serialize algorithm ID as a byte
+    pub fn to_u8(&self) -> u8 {
+        *self as u8
+    }
+}

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -1,0 +1,231 @@
+//! Object attributes specifying which operations are allowed to be performed
+
+// Apparently bitflags isn't clippy-safe
+#![allow(unknown_lints, redundant_field_names, suspicious_arithmetic_impl)]
+
+use byteorder::{BigEndian, ByteOrder};
+use failure::Error;
+use std::slice;
+
+bitflags! {
+    /// Object attributes specifying which operations are allowed to be performed
+    pub struct Capability: u64 {
+        /// asymmetric_decrypt_ecdh: perform ECDH operation
+        const ASYMMETRIC_DECRYPT_ECDH = 0x800;
+
+        /// asymmetric_decrypt_oaep: perform RSA-OAEP decryption
+        const ASYMMETRIC_DECRYPT_OAEP = 0x400;
+
+        /// asymmetric_decrypt_pkcs: perform RSA-PKCS1v1.5 decryption
+        const ASYMMETRIC_DECRYPT_PKCS = 0x200;
+
+        /// asymmetric_gen: generate asymmetric objects
+        const ASYMMETRIC_GEN = 0x10;
+
+        /// asymmetric_sign_ecdsa: compute ECDSA digital signature
+        const ASYMMETRIC_SIGN_ECDSA = 0x80;
+
+        /// asymmetric_sign_eddsa: compute EdDSA (i.e. Ed25519) digital signature
+        const ASYMMETRIC_SIGN_EDDSA = 0x100;
+
+        /// asymmetric_sign_pkcs: compute RSA-PKCS1v1.5 digital signature
+        const ASYMMETRIC_SIGN_PKCS = 0x20;
+
+        /// asymmetric_sign_pss: compute RSA-PSS digital signature
+        const ASYMMETRIC_SIGN_PSS = 0x40;
+
+        /// attest: create attestation (i.e. X.509 certificate) about an asymmetric object
+        const ATTEST = 0x4_0000_0000;
+
+        /// audit: read the log store
+        const AUDIT = 0x100_0000;
+
+        /// delete_asymmetric: delete asymmetric key objects
+        const DELETE_ASYMMETRIC = 0x200_0000_0000;
+
+        /// delete_authkey: delete AuthKey objects
+        const DELETE_AUTHKEY = 0x100_0000_0000;
+
+        /// delete_hmac_key: delete HMACKey objects
+        const DELETE_HMACKEY = 0x800_0000_0000;
+
+        /// delete_opaque: delete opaque objects
+        const DELETE_OPAQUE = 0x80_0000_0000;
+
+        /// delete_otp_aead_key: delete OTPAEADKey objects
+        const DELETE_OTP_AEAD_KEY = 0x2000_0000_0000;
+
+        /// delete_template: delete template objects
+        const DELETE_TEMPLATE = 0x1000_0000_0000;
+
+        /// delete_wrap_key: delete WrapKey objects
+        const DELETE_WRAPKEY = 0x400_0000_0000;
+
+        /// export_under_wrap: mark an object as exportable under keywrap
+        const EXPORT_UNDER_WRAP = 0x1_0000;
+
+        /// export_wrapped: export objects under keywrap
+        const EXPORT_WRAPPED = 0x1000;
+
+        /// generate_otp_aead_key: generate OTPAEADKey objects
+        const GENERATE_OTP_AEAD_KEY = 0x10_0000_0000;
+
+        /// generate_wrapkey: generate wrapkey objects
+        const GENERATE_WRAPKEY = 0x8000;
+
+        /// get_opaque: read opaque objects
+        const GET_OPAQUE = 0x1;
+
+        /// get_option: read device-global options
+        const GET_OPTION = 0x4_0000;
+
+        /// get_randomness: extract random bytes
+        const GET_RANDOMNESS = 0x8_0000;
+
+        /// get_template: read template objects
+        const GET_TEMPLATE = 0x400_0000;
+
+        /// hmackey_generate: generate HMACKey objects
+        const HMACKEY_GENERATE = 0x20_0000;
+
+        /// hmac_data: compute HMAC for data
+        const HMAC_DATA = 0x40_0000;
+
+        /// hmac_verify: verify HMAC for data
+        const HMAC_VERIFY = 0x80_0000;
+
+        /// import_wrapped: import keywrapped objects
+        const IMPORT_WRAPPED = 0x2000;
+
+        /// otp_aead_create: create an OTP AEAD
+        const OTP_AEAD_CREATE = 0x4000_0000;
+
+        /// otp_aead_random: create an OTP AEAD from random data
+        const OTP_AEAD_RANDOM = 0x8000_0000;
+
+        /// otp_aead_rewrap_from: rewrap AEADs from one OTPAEADKey Object to another
+        const OTP_AEAD_REWRAP_FROM = 0x1_0000_0000;
+
+        /// otp_aead_rewrap_to: rewrap AEADs to one OTPAEADKey Object from another
+        const OTP_AEAD_REWRAP_TO = 0x2_0000_0000;
+
+        /// otp_decrypt: decrypt OTP
+        const OTP_DECRYPT = 0x2000_0000;
+
+        /// put_asymmetric: write asymmetric objects
+        const PUT_ASYMMETRIC =  0x8;
+
+        /// put_authkey: write AuthKey objects
+        const PUT_AUTHKEY = 0x4;
+
+        /// put_hmackey: write HMACKey objects
+        const PUT_HMACKEY = 0x10_0000;
+
+        /// put_opaque: Write Opaque Objects
+        const PUT_OPAQUE = 0x2;
+
+        /// put_option: write device-global options
+        const PUT_OPTION = 0x2_0000;
+
+        /// put_otp_aead_key: write OTPAEADKey objects
+        const PUT_OTP_AEAD_KEY = 0x8_0000_0000;
+
+        /// put_template: write template objects
+        const PUT_TEMPLATE = 0x800_0000;
+
+        /// put_wrapkey: write WrapKey objects
+        const PUT_WRAPKEY = 0x4000;
+
+        /// reset: factory reset the device
+        const RESET = 0x1000_0000;
+
+        /// ssh_certify: sign SSH certificates
+        const SSH_CERTIFY = 0x200_0000;
+
+        /// unwrap_data: unwrap user-provided data
+        const UNWRAP_DATA = 0x40_0000_0000;
+
+        /// wrap_data: wrap user-provided data
+        const WRAP_DATA = 0x20_0000_0000;
+    }
+}
+
+impl Capability {
+    /// Set of all capabilities
+    pub fn iter() -> slice::Iter<'static, Self> {
+        // TODO: does bitflags provide this functionality?
+        [
+            Self::ASYMMETRIC_DECRYPT_ECDH,
+            Self::ASYMMETRIC_DECRYPT_OAEP,
+            Self::ASYMMETRIC_DECRYPT_PKCS,
+            Self::ASYMMETRIC_GEN,
+            Self::ASYMMETRIC_SIGN_ECDSA,
+            Self::ASYMMETRIC_SIGN_EDDSA,
+            Self::ASYMMETRIC_SIGN_PKCS,
+            Self::ASYMMETRIC_SIGN_PSS,
+            Self::ATTEST,
+            Self::AUDIT,
+            Self::DELETE_ASYMMETRIC,
+            Self::DELETE_AUTHKEY,
+            Self::DELETE_HMACKEY,
+            Self::DELETE_OPAQUE,
+            Self::DELETE_OTP_AEAD_KEY,
+            Self::DELETE_TEMPLATE,
+            Self::DELETE_WRAPKEY,
+            Self::EXPORT_UNDER_WRAP,
+            Self::EXPORT_WRAPPED,
+            Self::GENERATE_OTP_AEAD_KEY,
+            Self::GENERATE_WRAPKEY,
+            Self::GET_OPAQUE,
+            Self::GET_OPTION,
+            Self::GET_RANDOMNESS,
+            Self::GET_TEMPLATE,
+            Self::HMACKEY_GENERATE,
+            Self::HMAC_DATA,
+            Self::HMAC_VERIFY,
+            Self::IMPORT_WRAPPED,
+            Self::OTP_AEAD_CREATE,
+            Self::OTP_AEAD_RANDOM,
+            Self::OTP_AEAD_REWRAP_FROM,
+            Self::OTP_AEAD_REWRAP_TO,
+            Self::OTP_DECRYPT,
+            Self::PUT_ASYMMETRIC,
+            Self::PUT_AUTHKEY,
+            Self::PUT_HMACKEY,
+            Self::PUT_OPAQUE,
+            Self::PUT_OPTION,
+            Self::PUT_OTP_AEAD_KEY,
+            Self::PUT_TEMPLATE,
+            Self::PUT_WRAPKEY,
+            Self::RESET,
+            Self::SSH_CERTIFY,
+            Self::UNWRAP_DATA,
+            Self::WRAP_DATA,
+        ].iter()
+    }
+
+    /// Parse capabilities from a byte serialization
+    pub fn parse(bytes: &[u8]) -> Result<Vec<Self>, Error> {
+        if bytes.len() != 8 {
+            bail!("invalid capability length {} (expected {})", bytes.len(), 8);
+        }
+
+        let bitfield = BigEndian::read_u64(bytes);
+        let mut result = vec![];
+
+        for capability in Self::iter() {
+            if bitfield & capability.bits() != 0 {
+                result.push(*capability);
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Convert an array of Capability objects to a 64-bit integer bitfield
+    pub fn bitfield(capabilities: &[Self]) -> u64 {
+        capabilities
+            .iter()
+            .fold(0, |result, capability| result | capability.bits())
+    }
+}

--- a/src/commands/delete_object.rs
+++ b/src/commands/delete_object.rs
@@ -1,0 +1,53 @@
+//! Request data for `CommandType::DeleteObject`
+
+use {ObjectId, ObjectType};
+use byteorder::{BigEndian, WriteBytesExt};
+#[cfg(feature = "mockhsm")]
+use byteorder::ByteOrder;
+use responses::DeleteObjectResponse;
+use super::{Command, CommandType};
+#[cfg(feature = "mockhsm")]
+use super::{CommandMessage, Error};
+
+/// Request data for `CommandType::DeleteObject`
+///
+/// <https://developers.yubico.com/YubiHSM2/Commands/Delete_Object.html>
+#[derive(Debug)]
+pub struct DeleteObjectCommand {
+    /// Object ID to delete
+    pub object_id: ObjectId,
+
+    /// Type of object to delete
+    pub object_type: ObjectType,
+}
+
+impl Command for DeleteObjectCommand {
+    const COMMAND_TYPE: CommandType = CommandType::DeleteObject;
+    type ResponseType = DeleteObjectResponse;
+
+    /// Serialize data
+    // TODO: procedurally generate this
+    fn into_vec(self) -> Vec<u8> {
+        let mut data = Vec::with_capacity(3);
+        data.write_u16::<BigEndian>(self.object_id).unwrap();
+        data.push(self.object_type.to_u8());
+        data
+    }
+
+    /// Deserialize data
+    #[cfg(feature = "mockhsm")]
+    fn parse(command_msg: CommandMessage) -> Result<Self, Error> {
+        if command_msg.data.len() != 3 {
+            bail!(
+                "invalid command data length {} (expected {})",
+                command_msg.len(),
+                3
+            );
+        }
+
+        Ok(Self {
+            object_id: BigEndian::read_u16(&command_msg.data[..2]),
+            object_type: ObjectType::from_u8(command_msg.data[2])?,
+        })
+    }
+}

--- a/src/commands/echo.rs
+++ b/src/commands/echo.rs
@@ -1,0 +1,34 @@
+//! Request data for `CommandType::Echo`
+
+use responses::EchoResponse;
+use super::{Command, CommandType};
+#[cfg(feature = "mockhsm")]
+use super::{CommandMessage, Error};
+
+/// Request data for `CommandType::Echo`
+///
+/// <https://developers.yubico.com/YubiHSM2/Commands/Echo.html>
+#[derive(Debug)]
+pub struct EchoCommand {
+    /// Message to echo
+    pub message: Vec<u8>,
+}
+
+impl Command for EchoCommand {
+    const COMMAND_TYPE: CommandType = CommandType::Echo;
+    type ResponseType = EchoResponse;
+
+    /// Serialize data
+    // TODO: procedurally generate this
+    fn into_vec(self) -> Vec<u8> {
+        self.message
+    }
+
+    /// Deserialize data
+    #[cfg(feature = "mockhsm")]
+    fn parse(command_msg: CommandMessage) -> Result<Self, Error> {
+        Ok(Self {
+            message: command_msg.data,
+        })
+    }
+}

--- a/src/commands/gen_asymmetric_key.rs
+++ b/src/commands/gen_asymmetric_key.rs
@@ -1,0 +1,86 @@
+//! Request data for `CommandType::GenAsymmetricKey`
+
+use {Algorithm, Capability, Domain, ObjectId, ObjectLabel};
+use byteorder::{BigEndian, WriteBytesExt};
+#[cfg(feature = "mockhsm")]
+use byteorder::ByteOrder;
+use responses::GenAsymmetricKeyResponse;
+use super::{Command, CommandType};
+#[cfg(feature = "mockhsm")]
+use super::{CommandMessage, Error};
+
+// NOTE: this is incorrectly documented as 2 + 40 + 2 + 4 + 1
+const LENGTH: usize = 2 + 40 + 2 + 8 + 1;
+
+/// Request data for `CommandType::GenAsymmetricKey`
+///
+/// <https://developers.yubico.com/YubiHSM2/Commands/Generate_Asymmetric_Key.html>
+#[derive(Debug)]
+pub struct GenAsymmetricKeyCommand {
+    /// ID of the key
+    pub key_id: ObjectId,
+
+    /// Label for the key (40-bytes)
+    pub label: ObjectLabel,
+
+    /// Domains in which the key will be accessible
+    pub domains: Vec<Domain>,
+
+    /// Capabilities of the key
+    pub capabilities: Vec<Capability>,
+
+    /// Key algorithm
+    pub algorithm: Algorithm,
+}
+
+impl Command for GenAsymmetricKeyCommand {
+    const COMMAND_TYPE: CommandType = CommandType::GenAsymmetricKey;
+    type ResponseType = GenAsymmetricKeyResponse;
+
+    /// Serialize data
+    // TODO: procedurally generate this
+    fn into_vec(self) -> Vec<u8> {
+        let mut data = Vec::with_capacity(LENGTH);
+
+        // Key ID
+        data.write_u16::<BigEndian>(self.key_id).unwrap();
+
+        // Label (padded to 40-bytes)
+        data.extend_from_slice(&self.label.0);
+
+        // Domains
+        data.write_u16::<BigEndian>(Domain::bitfield(&self.domains))
+            .unwrap();
+
+        // Capabilities
+        data.write_u64::<BigEndian>(Capability::bitfield(&self.capabilities))
+            .unwrap();
+
+        // Algorithm
+        data.push(self.algorithm.to_u8());
+
+        data
+    }
+
+    /// Deserialize data
+    #[cfg(feature = "mockhsm")]
+    fn parse(command_msg: CommandMessage) -> Result<Self, Error> {
+        let bytes = command_msg.data;
+
+        if bytes.len() != LENGTH {
+            bail!(
+                "expected {}-byte object entry (got {})",
+                LENGTH,
+                bytes.len()
+            );
+        }
+
+        Ok(Self {
+            key_id: BigEndian::read_u16(&bytes[..2]),
+            label: ObjectLabel::new(&bytes[2..42])?,
+            domains: Domain::parse(&bytes[42..44])?,
+            capabilities: Capability::parse(&bytes[44..52])?,
+            algorithm: Algorithm::from_u8(bytes[52])?,
+        })
+    }
+}

--- a/src/commands/get_object_info.rs
+++ b/src/commands/get_object_info.rs
@@ -1,0 +1,53 @@
+//! Request data for `CommandType::GetObjectInfo`
+
+use {ObjectId, ObjectType};
+use byteorder::{BigEndian, WriteBytesExt};
+#[cfg(feature = "mockhsm")]
+use byteorder::ByteOrder;
+use responses::GetObjectInfoResponse;
+use super::{Command, CommandType};
+#[cfg(feature = "mockhsm")]
+use super::{CommandMessage, Error};
+
+/// Command to delete an object
+///
+/// <https://developers.yubico.com/YubiHSM2/Commands/Delete_Object.html>
+#[derive(Debug)]
+pub struct GetObjectInfoCommand {
+    /// Object ID to obtain information about
+    pub object_id: ObjectId,
+
+    /// Type of object to obtain information about
+    pub object_type: ObjectType,
+}
+
+impl Command for GetObjectInfoCommand {
+    const COMMAND_TYPE: CommandType = CommandType::GetObjectInfo;
+    type ResponseType = GetObjectInfoResponse;
+
+    /// Serialize data
+    // TODO: procedurally generate this
+    fn into_vec(self) -> Vec<u8> {
+        let mut data = Vec::with_capacity(3);
+        data.write_u16::<BigEndian>(self.object_id).unwrap();
+        data.push(self.object_type.to_u8());
+        data
+    }
+
+    /// Deserialize data
+    #[cfg(feature = "mockhsm")]
+    fn parse(command_msg: CommandMessage) -> Result<Self, Error> {
+        if command_msg.data.len() != 3 {
+            bail!(
+                "invalid command data length {} (expected {})",
+                command_msg.len(),
+                3
+            );
+        }
+
+        Ok(Self {
+            object_id: BigEndian::read_u16(&command_msg.data[..2]),
+            object_type: ObjectType::from_u8(command_msg.data[2])?,
+        })
+    }
+}

--- a/src/commands/list_objects.rs
+++ b/src/commands/list_objects.rs
@@ -1,0 +1,33 @@
+//! Request data for `CommandType::ListObjects`
+
+use responses::ListObjectsResponse;
+use super::{Command, CommandType};
+#[cfg(feature = "mockhsm")]
+use super::{CommandMessage, Error};
+
+/// Request data for `CommandType::ListObjects`
+///
+/// <https://developers.yubico.com/YubiHSM2/Commands/List_Objects.html>
+#[derive(Debug)]
+pub struct ListObjectsCommand {}
+
+impl Command for ListObjectsCommand {
+    const COMMAND_TYPE: CommandType = CommandType::ListObjects;
+    type ResponseType = ListObjectsResponse;
+
+    /// Serialize data
+    // TODO: procedurally generate this
+    fn into_vec(self) -> Vec<u8> {
+        vec![]
+    }
+
+    /// Deserialize data
+    #[cfg(feature = "mockhsm")]
+    fn parse(command_msg: CommandMessage) -> Result<Self, Error> {
+        if !command_msg.data.is_empty() {
+            bail!("CommandType::ListObjects filters are not supported");
+        }
+
+        Ok(Self {})
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,44 @@
+//! Command (i.e. request) and response structs for `YubiHSM2` commands
+//!
+//! The eventual goal is to procedurally generate serializers/deserializers
+//! for all of these structs declaratively (using e.g. serde). See:
+//!
+//! <https://github.com/tendermint/yubihsm-client/issues/3>
+
+mod delete_object;
+mod echo;
+mod gen_asymmetric_key;
+mod get_object_info;
+mod list_objects;
+
+pub use self::delete_object::DeleteObjectCommand;
+pub use self::echo::EchoCommand;
+pub use self::gen_asymmetric_key::GenAsymmetricKeyCommand;
+pub use self::get_object_info::GetObjectInfoCommand;
+pub use self::list_objects::ListObjectsCommand;
+
+#[cfg(feature = "mockhsm")]
+pub use failure::Error;
+use responses::Response;
+use securechannel::{CommandMessage, CommandType};
+
+pub(crate) trait Command: Into<CommandMessage> {
+    /// Command ID for this command
+    const COMMAND_TYPE: CommandType;
+
+    /// Response type for this command
+    type ResponseType: Response;
+
+    /// Serialize this command as a byte vector
+    fn into_vec(self) -> Vec<u8>;
+
+    /// Deserialize command from an encrypted channel message
+    #[cfg(feature = "mockhsm")]
+    fn parse(command_msg: CommandMessage) -> Result<Self, Error>;
+}
+
+impl<C: Command> From<C> for CommandMessage {
+    fn from(command: C) -> CommandMessage {
+        Self::new(C::COMMAND_TYPE, command.into_vec())
+    }
+}

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -1,0 +1,58 @@
+//! Logical partitions within the `YubiHSM2`, allowing several applications to
+//! share the device concurrently
+
+use byteorder::{BigEndian, ByteOrder};
+use failure::Error;
+
+use super::SessionError;
+
+/// Logical partition within the `YubiHSM2`
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Domain(pub(crate) u8);
+
+impl Domain {
+    /// Parse domains from a byte serialization
+    pub fn parse(bytes: &[u8]) -> Result<Vec<Self>, Error> {
+        if bytes.len() != 2 {
+            bail!("invalid domain length {} (expected {})", bytes.len(), 2);
+        }
+
+        let bitfield = BigEndian::read_u16(bytes);
+        let mut result = vec![];
+
+        for i in 1..16 {
+            if bitfield & (1 << i) != 0 {
+                result.push(Domain::new(i).unwrap())
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Convert an array of Domain objects to a 16-bit integer bitfield
+    pub fn bitfield(domains: &[Self]) -> u16 {
+        domains
+            .iter()
+            .fold(0, |result, domain| result | (1 << domain.0))
+    }
+
+    /// Create a new Domain
+    pub fn new(domain: u8) -> Result<Self, Error> {
+        if domain < 1 || domain > 16 {
+            fail!(SessionError::ProtocolError, "invalid domain: {}", domain);
+        }
+
+        Ok(Domain(domain))
+    }
+
+    /// Create a Domain from a byte serialization
+    #[inline]
+    pub fn from_u8(domain: u8) -> Result<Self, Error> {
+        Self::new(domain)
+    }
+
+    /// Serialize this domain as a byte
+    pub fn to_u8(&self) -> u8 {
+        self.0
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,16 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 
 extern crate aesni;
+#[macro_use]
+extern crate bitflags;
 extern crate block_modes;
 extern crate byteorder;
 extern crate clear_on_drop;
 extern crate cmac;
 extern crate constant_time_eq;
-#[cfg_attr(feature = "mockhsm", macro_use)]
+#[cfg(feature = "mockhsm")]
+extern crate ed25519_dalek;
+#[macro_use]
 extern crate failure;
 #[macro_use]
 extern crate failure_derive;
@@ -40,17 +44,26 @@ macro_rules! fail {
     };
 }
 
+pub mod algorithm;
+pub mod capability;
+mod commands;
 pub mod connector;
+pub mod domain;
 #[cfg(any(feature = "mockhsm"))]
 pub mod mockhsm;
 pub mod object;
+pub mod responses;
 mod securechannel;
 pub mod session;
 
+pub use algorithm::Algorithm;
+pub use capability::Capability;
 pub use connector::Connector;
-pub use object::{Object, ObjectType};
+pub use domain::Domain;
+pub use object::Id as ObjectId;
+pub use object::Label as ObjectLabel;
+pub use object::Origin as ObjectOrigin;
+pub use object::Type as ObjectType;
+pub use object::SequenceId;
 pub use securechannel::SessionId;
 pub use session::{Session, SessionError};
-
-/// Key identifiers
-pub type KeyId = u16;

--- a/src/object.rs
+++ b/src/object.rs
@@ -3,41 +3,120 @@
 //! For more information, see:
 //! <https://developers.yubico.com/YubiHSM2/Concepts/Object.html>
 
-use byteorder::{BigEndian, ByteOrder};
 use failure::Error;
+use std::{fmt, str};
 
-use super::SessionError;
+/// Number of bytes in a label on an object (fixed-size)
+pub const LABEL_SIZE: usize = 40;
 
-/// Information about an object
-#[derive(Debug, Eq, PartialEq)]
-pub struct Object {
-    /// Object identifiers
-    pub id: u16,
+/// Object identifiers
+pub type Id = u16;
 
-    /// Object types
-    pub object_type: ObjectType,
-}
+/// Sequence identifiers
+pub type SequenceId = u8;
 
-impl Object {
-    pub(crate) fn from_list_response(bytes: &[u8]) -> Result<Self, Error> {
-        if bytes.len() != 4 {
-            fail!(
-                SessionError::ProtocolError,
-                "expected 4-byte object entry (got {})",
-                bytes.len()
+/// Labels attached to objects
+pub struct Label(pub [u8; LABEL_SIZE]);
+
+impl Label {
+    /// Create a new label from a slice, returning an error if it's over 40-bytes
+    pub fn new(label_slice: &[u8]) -> Result<Self, Error> {
+        if label_slice.len() > LABEL_SIZE {
+            bail!(
+                "label too long: {}-bytes (max {})",
+                label_slice.len(),
+                LABEL_SIZE
             );
         }
 
-        Ok(Self {
-            id: BigEndian::read_u16(&bytes[..2]),
-            object_type: ObjectType::from_u8(bytes[2])?,
+        let mut bytes = [0u8; LABEL_SIZE];
+        bytes[..label_slice.len()].copy_from_slice(label_slice);
+        Ok(Label(bytes))
+    }
+
+    /// Create a string representation of this label
+    pub fn to_string(&self) -> Result<String, Error> {
+        let mut string = str::from_utf8(&self.0)?.to_owned();
+
+        // Ignore trailing zeroes when converting to a String
+        if let Some(pos) = string.find('\0') {
+            string.truncate(pos);
+        }
+
+        Ok(string)
+    }
+}
+
+impl AsRef<[u8]> for Label {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl Clone for Label {
+    fn clone(&self) -> Self {
+        Self::new(self.as_ref()).unwrap()
+    }
+}
+
+impl fmt::Debug for Label {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let string = self.to_string()
+            .unwrap_or_else(|_| "[INVALID UTF-8 CHARACTER IN LABEL]".to_owned());
+
+        write!(f, "{:?}", string)
+    }
+}
+
+impl<'a> From<&'a str> for Label {
+    fn from(string: &'a str) -> Self {
+        Self::new(string.as_bytes()).unwrap()
+    }
+}
+
+impl PartialEq for Label {
+    fn eq(&self, other: &Self) -> bool {
+        self.0[..] == other.0[..]
+    }
+}
+
+/// Information about how a key was originally generated
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Origin {
+    /// Object was generated on the device
+    Generated = 0x01,
+
+    /// Object was imported from the host
+    Imported = 0x02,
+
+    /// Object was generated on a device, keywrapped, and reimported
+    WrappedGenerated = 0x11,
+
+    /// Object was imported from host, keywrapped, and reimported
+    WrappedImported = 0x12,
+}
+
+impl Origin {
+    /// Convert an unsigned byte into a ObjectOrigin (if valid)
+    pub fn from_u8(byte: u8) -> Result<Self, Error> {
+        Ok(match byte {
+            0x01 => Origin::Generated,
+            0x02 => Origin::Imported,
+            0x11 => Origin::WrappedGenerated,
+            0x12 => Origin::WrappedImported,
+            _ => bail!("invalid object origin: {}", byte),
         })
+    }
+
+    /// Serialize this object origin as a byte
+    pub fn to_u8(&self) -> u8 {
+        *self as u8
     }
 }
 
 /// Types of objects
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum ObjectType {
+pub enum Type {
     /// Raw data
     Opaque = 0x01,
 
@@ -60,18 +139,23 @@ pub enum ObjectType {
     OTPAEADKey = 0x07,
 }
 
-impl ObjectType {
+impl Type {
     /// Convert an unsigned byte into a ObjectType (if valid)
     pub fn from_u8(byte: u8) -> Result<Self, Error> {
         Ok(match byte {
-            0x01 => ObjectType::Opaque,
-            0x02 => ObjectType::AuthKey,
-            0x03 => ObjectType::Asymmetric,
-            0x04 => ObjectType::WrapKey,
-            0x05 => ObjectType::HMACKey,
-            0x06 => ObjectType::Template,
-            0x07 => ObjectType::OTPAEADKey,
-            _ => fail!(SessionError::ProtocolError, "invalid object type: {}", byte),
+            0x01 => Type::Opaque,
+            0x02 => Type::AuthKey,
+            0x03 => Type::Asymmetric,
+            0x04 => Type::WrapKey,
+            0x05 => Type::HMACKey,
+            0x06 => Type::Template,
+            0x07 => Type::OTPAEADKey,
+            _ => bail!("invalid object type: {}", byte),
         })
+    }
+
+    /// Serialize this object type as a byte
+    pub fn to_u8(&self) -> u8 {
+        *self as u8
     }
 }

--- a/src/responses/delete_object.rs
+++ b/src/responses/delete_object.rs
@@ -1,0 +1,27 @@
+//! Response from `CommandType::DeleteObject`
+
+use failure::Error;
+use super::{CommandType, Response};
+
+/// Response from `CommandType::DeleteObject`
+///
+/// <https://developers.yubico.com/YubiHSM2/Commands/Delete_Object.html>
+#[derive(Debug)]
+pub struct DeleteObjectResponse {}
+
+impl Response for DeleteObjectResponse {
+    const COMMAND_TYPE: CommandType = CommandType::DeleteObject;
+
+    /// Parse response from HSM
+    // TODO: procedurally generate this
+    fn parse(_bytes: Vec<u8>) -> Result<Self, Error> {
+        Ok(Self {})
+    }
+
+    /// Serialize data
+    // TODO: procedurally generate this
+    #[cfg(feature = "mockhsm")]
+    fn into_vec(self) -> Vec<u8> {
+        vec![]
+    }
+}

--- a/src/responses/echo.rs
+++ b/src/responses/echo.rs
@@ -1,0 +1,30 @@
+//! Response from `CommandType::Echo`
+
+use failure::Error;
+use super::{CommandType, Response};
+
+/// Response from `CommandType::Echo`
+///
+/// <https://developers.yubico.com/YubiHSM2/Commands/Echo.html>
+#[derive(Debug)]
+pub struct EchoResponse {
+    /// Echo response
+    pub message: Vec<u8>,
+}
+
+impl Response for EchoResponse {
+    const COMMAND_TYPE: CommandType = CommandType::Echo;
+
+    /// Parse response from HSM
+    // TODO: procedurally generate this
+    fn parse(bytes: Vec<u8>) -> Result<Self, Error> {
+        Ok(Self { message: bytes })
+    }
+
+    /// Serialize data
+    // TODO: procedurally generate this
+    #[cfg(feature = "mockhsm")]
+    fn into_vec(self) -> Vec<u8> {
+        self.message
+    }
+}

--- a/src/responses/gen_asymmetric_key.rs
+++ b/src/responses/gen_asymmetric_key.rs
@@ -1,0 +1,42 @@
+//! Response from `CommandType::GenAsymmetricKey`
+
+use ObjectId;
+use byteorder::{BigEndian, ByteOrder};
+#[cfg(feature = "mockhsm")]
+use byteorder::WriteBytesExt;
+use failure::Error;
+use super::{CommandType, Response};
+
+/// Response from `CommandType::GenAsymmetricKey`
+///
+/// <https://developers.yubico.com/YubiHSM2/Commands/Generate_Asymmetric_Key.html>
+#[derive(Debug)]
+pub struct GenAsymmetricKeyResponse {
+    /// ID of the key
+    pub key_id: ObjectId,
+}
+
+impl Response for GenAsymmetricKeyResponse {
+    const COMMAND_TYPE: CommandType = CommandType::GenAsymmetricKey;
+
+    /// Parse response from HSM
+    // TODO: procedurally generate this
+    fn parse(bytes: Vec<u8>) -> Result<Self, Error> {
+        if bytes.len() != 2 {
+            bail!("invalid response length {} (expected {})", bytes.len(), 2);
+        }
+
+        Ok(Self {
+            key_id: BigEndian::read_u16(&bytes),
+        })
+    }
+
+    /// Serialize data
+    // TODO: procedurally generate this
+    #[cfg(feature = "mockhsm")]
+    fn into_vec(self) -> Vec<u8> {
+        let mut data = Vec::with_capacity(2);
+        data.write_u16::<BigEndian>(self.key_id).unwrap();
+        data
+    }
+}

--- a/src/responses/get_object_info.rs
+++ b/src/responses/get_object_info.rs
@@ -1,0 +1,119 @@
+//! Response from `CommandType::GetObjectInfo`
+
+use {Algorithm, Capability, Domain, ObjectLabel, ObjectOrigin, ObjectType, SequenceId};
+use byteorder::{BigEndian, ByteOrder};
+#[cfg(feature = "mockhsm")]
+use byteorder::WriteBytesExt;
+use failure::Error;
+use super::{CommandType, Response};
+
+/// Size of a `CommandType::GetObjectInfo` response
+const LENGTH: usize = 8 + 2 + 2 + 2 + 1 + 1 + 1 + 1 + 40 + 8;
+
+/// Response from `CommandType::GetObjectInfo`
+///
+/// <https://developers.yubico.com/YubiHSM2/Commands/Get_Object_Info.html>
+#[derive(Debug)]
+pub struct GetObjectInfoResponse {
+    /// Capabilities
+    pub capabilities: Vec<Capability>,
+
+    /// Object identifier
+    pub id: u16,
+
+    /// Length of object in bytes
+    pub length: u16,
+
+    /// Domains from which object is accessible
+    pub domains: Vec<Domain>,
+
+    /// Object type
+    pub object_type: ObjectType,
+
+    /// Algorithm this object is intended to be used with
+    pub algorithm: Algorithm,
+
+    /// Sequence: number of times an object with this key ID and type has
+    /// previously existed
+    pub sequence: SequenceId,
+
+    /// How did this object originate? (generated, imported, etc)
+    pub origin: ObjectOrigin,
+
+    /// Label of object
+    pub label: ObjectLabel,
+
+    /// Delegated Capabilities
+    pub delegated_capabilities: Vec<Capability>,
+}
+
+impl Response for GetObjectInfoResponse {
+    const COMMAND_TYPE: CommandType = CommandType::GetObjectInfo;
+
+    /// Parse response from HSM
+    // TODO: procedurally generate this
+    fn parse(bytes: Vec<u8>) -> Result<Self, Error> {
+        if bytes.len() != LENGTH {
+            bail!(
+                "expected {}-byte object entry (got {})",
+                LENGTH,
+                bytes.len()
+            );
+        }
+
+        Ok(Self {
+            capabilities: Capability::parse(&bytes[..8])?,
+            id: BigEndian::read_u16(&bytes[8..10]),
+            length: BigEndian::read_u16(&bytes[10..12]),
+            domains: Domain::parse(&bytes[12..14])?,
+            object_type: ObjectType::from_u8(bytes[14])?,
+            algorithm: Algorithm::from_u8(bytes[15])?,
+            sequence: bytes[16],
+            origin: ObjectOrigin::from_u8(bytes[17])?,
+            label: ObjectLabel::new(&bytes[18..58])?,
+            delegated_capabilities: Capability::parse(&bytes[58..66])?,
+        })
+    }
+
+    /// Serialize data
+    // TODO: procedurally generate this
+    #[cfg(feature = "mockhsm")]
+    fn into_vec(self) -> Vec<u8> {
+        let mut data = Vec::with_capacity(LENGTH);
+
+        // Capabilities
+        data.write_u64::<BigEndian>(Capability::bitfield(&self.capabilities))
+            .unwrap();
+
+        // Object ID
+        data.write_u16::<BigEndian>(self.id).unwrap();
+
+        // Object Length
+        data.write_u16::<BigEndian>(self.length).unwrap();
+
+        // Domains
+        data.write_u16::<BigEndian>(Domain::bitfield(&self.domains))
+            .unwrap();
+
+        // Object Type
+        data.push(self.object_type.to_u8());
+
+        // Algorithm
+        data.push(self.algorithm.to_u8());
+
+        // Sequence Number
+        data.push(self.sequence);
+
+        // Object Origin (Generated/Imported)
+        data.push(self.origin.to_u8());
+
+        // Label (padded to 40-bytes)
+        data.extend_from_slice(&self.label.0);
+
+        // Delegated Capabilities
+        data.write_u64::<BigEndian>(Capability::bitfield(&self.delegated_capabilities))
+            .unwrap();
+
+        data
+    }
+}

--- a/src/responses/list_objects.rs
+++ b/src/responses/list_objects.rs
@@ -1,0 +1,70 @@
+//! Response from `CommandType::ListObjects`
+
+use {ObjectId, ObjectType, SequenceId};
+use byteorder::{BigEndian, ByteOrder};
+#[cfg(feature = "mockhsm")]
+use byteorder::WriteBytesExt;
+use failure::Error;
+use super::{CommandType, Response};
+
+/// Response from `CommandType::ListObjects`
+///
+/// <https://developers.yubico.com/YubiHSM2/Commands/List_Objects.html>
+#[derive(Debug)]
+pub struct ListObjectsResponse {
+    /// Objects in the response
+    pub objects: Vec<ListObjectsEntry>,
+}
+
+/// Brief information about an object as returned from the `ListObjects` command
+#[derive(Debug)]
+pub struct ListObjectsEntry {
+    /// Object identifier
+    pub id: ObjectId,
+
+    /// Object type
+    pub object_type: ObjectType,
+
+    /// Sequence: number of times an object with this key ID and type has
+    /// previously existed
+    pub sequence: SequenceId,
+}
+
+impl Response for ListObjectsResponse {
+    const COMMAND_TYPE: CommandType = CommandType::ListObjects;
+
+    /// Parse response from HSM
+    // TODO: procedurally generate this
+    fn parse(bytes: Vec<u8>) -> Result<Self, Error> {
+        let mut objects = Vec::with_capacity(bytes.len() / 4);
+
+        for chunk in bytes.chunks(4) {
+            if chunk.len() != 4 {
+                bail!("expected 4-byte object entry (got {})", chunk.len());
+            }
+
+            objects.push(ListObjectsEntry {
+                id: BigEndian::read_u16(&chunk[..2]),
+                object_type: ObjectType::from_u8(chunk[2])?,
+                sequence: chunk[3],
+            })
+        }
+
+        Ok(Self { objects })
+    }
+
+    /// Serialize data
+    // TODO: procedurally generate this
+    #[cfg(feature = "mockhsm")]
+    fn into_vec(self) -> Vec<u8> {
+        let mut data = Vec::with_capacity(4 * self.objects.len());
+
+        for entry in self.objects {
+            data.write_u16::<BigEndian>(entry.id).unwrap();
+            data.push(entry.object_type.to_u8());
+            data.push(entry.sequence);
+        }
+
+        data
+    }
+}

--- a/src/responses/mod.rs
+++ b/src/responses/mod.rs
@@ -1,0 +1,30 @@
+//! Responses to commands sent from the HSM, intended as part of the public
+//! API of this crate.
+
+mod delete_object;
+mod echo;
+mod gen_asymmetric_key;
+mod get_object_info;
+mod list_objects;
+
+pub use self::delete_object::DeleteObjectResponse;
+pub use self::echo::EchoResponse;
+pub use self::gen_asymmetric_key::GenAsymmetricKeyResponse;
+pub use self::get_object_info::GetObjectInfoResponse;
+pub use self::list_objects::{ListObjectsEntry, ListObjectsResponse};
+
+pub use failure::Error;
+pub(crate) use securechannel::CommandType;
+
+pub(crate) trait Response: Sized {
+    /// Command ID this response is for
+    const COMMAND_TYPE: CommandType;
+
+    /// Parse response data into a response object
+    fn parse(bytes: Vec<u8>) -> Result<Self, Error>;
+
+    /// Serialize data
+    // TODO: procedurally generate this
+    #[cfg(feature = "mockhsm")]
+    fn into_vec(self) -> Vec<u8>;
+}

--- a/src/securechannel/command.rs
+++ b/src/securechannel/command.rs
@@ -15,7 +15,7 @@ use super::{Mac, SecureChannelError, SessionId, MAC_SIZE};
 /// A command sent from the host to the `YubiHSM2`. May or may not be
 /// authenticated using SCP03's chained/evolving MAC protocol.
 #[derive(Debug)]
-pub(crate) struct Command {
+pub(crate) struct CommandMessage {
     /// Type of command to be invoked
     pub command_type: CommandType,
 
@@ -29,7 +29,7 @@ pub(crate) struct Command {
     pub mac: Option<Mac>,
 }
 
-impl Command {
+impl CommandMessage {
     /// Create a new command message without a MAC
     pub fn new<T>(command_type: CommandType, command_data: T) -> Self
     where

--- a/src/securechannel/mod.rs
+++ b/src/securechannel/mod.rs
@@ -36,13 +36,13 @@ pub const KEY_SIZE: usize = 16;
 pub use self::challenge::{Challenge, CHALLENGE_SIZE};
 pub(crate) use self::channel::Channel;
 pub use self::channel::Id as SessionId;
-pub(crate) use self::command::Command;
+pub(crate) use self::command::CommandMessage;
 pub use self::command::CommandType;
 pub use self::context::{Context, CONTEXT_SIZE};
 pub use self::cryptogram::{Cryptogram, CRYPTOGRAM_SIZE};
 pub use self::error::SecureChannelError;
 pub(crate) use self::mac::{Mac, MAC_SIZE};
-pub(crate) use self::response::Response;
+pub(crate) use self::response::ResponseMessage;
 #[cfg(feature = "mockhsm")]
 pub(crate) use self::response::ResponseCode;
 pub use self::static_keys::StaticKeys;

--- a/src/securechannel/response.rs
+++ b/src/securechannel/response.rs
@@ -8,7 +8,7 @@ use super::{CommandType, Mac, SecureChannelError, SessionId, MAC_SIZE};
 
 /// Command responses
 #[derive(Debug, Eq, PartialEq)]
-pub struct Response {
+pub struct ResponseMessage {
     /// Success (for a given command type) or an error type
     pub code: ResponseCode,
 
@@ -22,7 +22,7 @@ pub struct Response {
     pub mac: Option<Mac>,
 }
 
-impl Response {
+impl ResponseMessage {
     /// Parse a response into a Response struct
     pub fn parse(mut bytes: Vec<u8>) -> Result<Self, Error> {
         if bytes.len() < 3 {
@@ -86,11 +86,11 @@ impl Response {
 
     /// Create a new response without an associated session
     #[cfg(feature = "mockhsm")]
-    pub fn new<T>(code: ResponseCode, response_data: T) -> Response
+    pub fn new<T>(code: ResponseCode, response_data: T) -> ResponseMessage
     where
         T: Into<Vec<u8>>,
     {
-        Response {
+        ResponseMessage {
             code,
             session_id: None,
             data: response_data.into(),
@@ -120,7 +120,7 @@ impl Response {
 
     /// Create a successful response
     #[cfg(feature = "mockhsm")]
-    pub fn success<T>(command_type: CommandType, response_data: T) -> Response
+    pub fn success<T>(command_type: CommandType, response_data: T) -> ResponseMessage
     where
         T: Into<Vec<u8>>,
     {
@@ -133,6 +133,12 @@ impl Response {
             ResponseCode::Success(_) => true,
             _ => false,
         }
+    }
+
+    /// Create an error response
+    #[cfg(feature = "mockhsm")]
+    pub fn error(message: &str) -> ResponseMessage {
+        ResponseMessage::new(ResponseCode::MemoryError, message.as_bytes())
     }
 
     /// Did an error occur?

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3,7 +3,8 @@ extern crate yubihsm_client;
 #[cfg(feature = "mockhsm")]
 use std::thread;
 
-use yubihsm_client::{Connector, KeyId, ObjectType, Session};
+use yubihsm_client::{Algorithm, Capability, Connector, Domain, ObjectId, ObjectOrigin, ObjectType,
+                     Session};
 #[cfg(feature = "mockhsm")]
 use yubihsm_client::mockhsm::MockHSM;
 
@@ -16,10 +17,20 @@ const YUBIHSM_ADDR: &str = "127.0.0.1:12345";
 const MOCKHSM_ADDR: &str = "127.0.0.1:54321";
 
 /// Default auth key ID slot
-const DEFAULT_AUTH_KEY_ID: KeyId = 1;
+const DEFAULT_AUTH_KEY_ID: ObjectId = 1;
 
 /// Default password
 const DEFAULT_PASSWORD: &str = "password";
+
+/// Key ID to use for testing keygen/signing
+const TEST_KEY_ID: ObjectId = 100;
+
+/// Number of HTTP requests issued by the test suite
+///
+/// NOTE: This will need to be increased whenever adding additional tests
+/// to the suite.
+#[cfg(feature = "mockhsm")]
+const NUM_HTTP_REQUESTS: usize = 10;
 
 #[cfg(not(feature = "mockhsm"))]
 #[test]
@@ -30,19 +41,22 @@ fn yubihsm_integration_test() {
     let mut session = conn.create_session_from_password(DEFAULT_AUTH_KEY_ID, DEFAULT_PASSWORD)
         .unwrap_or_else(|err| panic!("error creating session: {:?}", err));
 
+    // Delete the key in TEST_KEY_ID slot it exists (we use it for testing)
+    // Ignore errors since the object may not exist yet
+    let _ = session.delete_object(TEST_KEY_ID, ObjectType::Asymmetric);
+
     integration_tests(&mut session);
 }
 
 #[cfg(feature = "mockhsm")]
-fn start_mockhsm(num_requests: usize) -> thread::JoinHandle<()> {
-    thread::spawn(move || MockHSM::new(MOCKHSM_ADDR).unwrap().run(num_requests))
+fn start_mockhsm() -> thread::JoinHandle<()> {
+    thread::spawn(move || MockHSM::new(MOCKHSM_ADDR).unwrap().run(NUM_HTTP_REQUESTS))
 }
 
 #[cfg(feature = "mockhsm")]
 #[test]
 fn mockhsm_integration_test() {
-    let num_requests = 5;
-    let mockhsm_thread = start_mockhsm(num_requests);
+    let mockhsm_thread = start_mockhsm();
 
     let conn = Connector::open(&format!("http://{}", MOCKHSM_ADDR))
         .unwrap_or_else(|err| panic!("cannot open connection to mockhsm: {:?}", err));
@@ -56,29 +70,86 @@ fn mockhsm_integration_test() {
 
 // Tests to be performed as part of our integration testing process
 fn integration_tests(session: &mut Session) {
+    // NOTE: if you are adding a new test, you may need to bump NUM_HTTP_TESTS
+    // as described at the top of this file
     echo_test(session);
+    generate_asymmetric_key_test(session);
     list_objects_test(session);
+    delete_object_test(session);
 }
 
 // Send a simple echo request
 fn echo_test(session: &mut Session) {
     let message = b"Hello, world!";
-    let echo_result = session
-        .echo(message)
+    let response = session
+        .echo(&message[..])
         .unwrap_or_else(|err| panic!("error sending echo: {:?}", err));
 
-    assert_eq!(&message[..], &echo_result[..]);
+    assert_eq!(&message[..], &response.message[..]);
+}
+
+// Generate an Ed25519 key
+fn generate_asymmetric_key_test(session: &mut Session) {
+    // Ensure the object does not already exist
+    assert!(
+        session
+            .get_object_info(TEST_KEY_ID, ObjectType::Asymmetric)
+            .is_err()
+    );
+
+    let label = "yubihsm-client.rs test key";
+    let domains = [Domain::new(1).unwrap()];
+    let capabilities = [Capability::ASYMMETRIC_SIGN_EDDSA];
+    let algorithm = Algorithm::EC_ED25519;
+
+    let response = session
+        .generate_asymmetric_key(
+            TEST_KEY_ID,
+            label.into(),
+            &domains,
+            &capabilities,
+            algorithm,
+        )
+        .unwrap_or_else(|err| panic!("error generating asymmetric key: {:?}", err));
+
+    assert_eq!(response.key_id, TEST_KEY_ID);
+    let object_info = session
+        .get_object_info(TEST_KEY_ID, ObjectType::Asymmetric)
+        .unwrap_or_else(|err| panic!("error getting object info: {:?}", err));
+
+    assert_eq!(object_info.capabilities, &capabilities);
+    assert_eq!(object_info.id, TEST_KEY_ID);
+    assert_eq!(object_info.domains, &domains);
+    assert_eq!(object_info.object_type, ObjectType::Asymmetric);
+    assert_eq!(object_info.algorithm, algorithm);
+    assert_eq!(object_info.origin, ObjectOrigin::Generated);
+    assert_eq!(&object_info.label.to_string().unwrap(), label);
 }
 
 // List the objects in the YubiHSM2
 fn list_objects_test(session: &mut Session) {
-    let objects = session
+    let response = session
         .list_objects()
         .unwrap_or_else(|err| panic!("error listing objects: {:?}", err));
 
-    assert_eq!(objects.len(), 1);
-    let object = &objects[0];
+    // Check type of the Ed25519 we created in generate_asymmetric_key_test()
+    let object = response.objects.iter().find(|i| i.id == 100).unwrap();
+    assert_eq!(object.object_type, ObjectType::Asymmetric)
+}
 
-    assert_eq!(object.id, 1);
-    assert_eq!(object.object_type, ObjectType::AuthKey)
+// Delete an object in the YubiHSM2
+fn delete_object_test(session: &mut Session) {
+    // The first request to delete should succeed because the object exists
+    assert!(
+        session
+            .delete_object(TEST_KEY_ID, ObjectType::Asymmetric)
+            .is_ok()
+    );
+
+    // The second request to delete should fail because it's already deleted
+    assert!(
+        session
+            .delete_object(TEST_KEY_ID, ObjectType::Asymmetric)
+            .is_err()
+    );
 }


### PR DESCRIPTION
This adds `Command` and `Response` traits which are used to provide a framework for extending the library with commands.

Commands and Responses are now split out as individual structs which, in theory, it should be possible to consume with a procedural macro for generating all serialization logic, possibly using serde.

This PR implements 3 new YubiHSM2 commands, developed in tandem with the command framework at the time it was being implemented:

- DeleteObject: delete an object stored in the HSM (e.g. a key)
- GenAsymmetricKey: randomly generate an asymmetric key
- GetObjectInfo: obtain information about an object