### PR TITLE
Use command/response framework to implement CreateSession

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -9,6 +9,7 @@ use serde::de::DeserializeOwned;
 use serializers::serialize;
 
 use {Algorithm, Capabilities, Domains, ObjectId, ObjectLabel, ObjectType};
+use securechannel::Challenge;
 use responses::*;
 
 pub(crate) trait Command: Serialize + DeserializeOwned + Sized {
@@ -23,6 +24,23 @@ impl<C: Command> From<C> for CommandMessage {
     fn from(command: C) -> CommandMessage {
         Self::new(C::COMMAND_TYPE, serialize(&command).unwrap())
     }
+}
+
+/// Request parameters for `CommandType::CreateSession`
+///
+/// <https://developers.yubico.com/YubiHSM2/Commands/Create_Session.html>
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CreateSessionCommand {
+    /// Authentication key ID to use
+    pub auth_key_id: ObjectId,
+
+    /// Randomly generated challenge from the host
+    pub host_challenge: Challenge,
+}
+
+impl Command for CreateSessionCommand {
+    const COMMAND_TYPE: CommandType = CommandType::CreateSession;
+    type ResponseType = CreateSessionResponse;
 }
 
 /// Request parameters for `CommandType::DeleteObject`

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -183,7 +183,7 @@ impl Connector {
     /// POST /connector/api with a given command message
     pub(crate) fn send_command(&self, cmd: CommandMessage) -> Result<ResponseMessage, Error> {
         let cmd_type = cmd.command_type;
-        let response_bytes = self.post("/connector/api", cmd.into_vec())?;
+        let response_bytes = self.post("/connector/api", cmd.into())?;
         let response = ResponseMessage::parse(response_bytes)?;
 
         if response.is_err() {

--- a/src/object.rs
+++ b/src/object.rs
@@ -80,7 +80,7 @@ impl<'a> From<&'a str> for Label {
 
 impl PartialEq for Label {
     fn eq(&self, other: &Self) -> bool {
-        self.0[..] == other.0[..]
+        self.0.as_ref() == other.0.as_ref()
     }
 }
 

--- a/src/securechannel/challenge.rs
+++ b/src/securechannel/challenge.rs
@@ -4,6 +4,7 @@ use rand::{OsRng, Rng};
 pub const CHALLENGE_SIZE: usize = 8;
 
 /// A challenge message, sent by either host or the card
+#[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 pub struct Challenge([u8; CHALLENGE_SIZE]);
 
 impl Challenge {

--- a/src/securechannel/channel.rs
+++ b/src/securechannel/channel.rs
@@ -164,7 +164,7 @@ impl Channel {
             );
         }
 
-        let mut mac = Cmac::<Aes128>::new_varkey(&self.mac_key[..]).unwrap();
+        let mut mac = Cmac::<Aes128>::new_varkey(self.mac_key.as_ref()).unwrap();
         mac.input(&self.mac_chaining_value);
         mac.input(&[command_type.to_u8()]);
 
@@ -220,7 +220,7 @@ impl Channel {
     pub fn encrypt_command(&mut self, command: CommandMessage) -> Result<CommandMessage, Error> {
         assert_eq!(self.security_level, SecurityLevel::Authenticated);
 
-        let mut message = command.into_vec();
+        let mut message: Vec<u8> = command.into();
         let pos = message.len();
 
         // Provide space at the end of the vec for the padding
@@ -283,7 +283,7 @@ impl Channel {
 
         assert_eq!(self.id, session_id, "session ID mismatch: {:?}", session_id);
 
-        let mut mac = Cmac::<Aes128>::new_varkey(&self.rmac_key[..]).unwrap();
+        let mut mac = Cmac::<Aes128>::new_varkey(self.rmac_key.as_ref()).unwrap();
         mac.input(&self.mac_chaining_value);
         mac.input(&[response.code.to_u8()]);
 
@@ -392,7 +392,7 @@ impl Channel {
             command.session_id
         );
 
-        let mut mac = Cmac::<Aes128>::new_varkey(&self.mac_key[..]).unwrap();
+        let mut mac = Cmac::<Aes128>::new_varkey(self.mac_key.as_ref()).unwrap();
         mac.input(&self.mac_chaining_value);
         mac.input(&[command.command_type.to_u8()]);
 
@@ -427,7 +427,7 @@ impl Channel {
     ) -> Result<ResponseMessage, Error> {
         assert_eq!(self.security_level, SecurityLevel::Authenticated);
 
-        let mut message = response.into_vec();
+        let mut message: Vec<u8> = response.into();
         let pos = message.len();
 
         // Provide space at the end of the vec for the padding
@@ -456,7 +456,7 @@ impl Channel {
         assert_eq!(self.security_level, SecurityLevel::Authenticated);
         let body = response_data.into();
 
-        let mut mac = Cmac::<Aes128>::new_varkey(&self.rmac_key[..]).unwrap();
+        let mut mac = Cmac::<Aes128>::new_varkey(self.rmac_key.as_ref()).unwrap();
         mac.input(&self.mac_chaining_value);
         mac.input(&[code.to_u8()]);
 

--- a/src/securechannel/command.rs
+++ b/src/securechannel/command.rs
@@ -138,9 +138,11 @@ impl CommandMessage {
 
         result
     }
+}
 
+impl Into<Vec<u8>> for CommandMessage {
     /// Serialize this Command, consuming it and creating a Vec<u8>
-    pub fn into_vec(mut self) -> Vec<u8> {
+    fn into(mut self) -> Vec<u8> {
         let mut result = Vec::with_capacity(3 + self.len());
         result.push(self.command_type as u8);
         result.write_u16::<BigEndian>(self.len() as u16).unwrap();

--- a/src/securechannel/cryptogram.rs
+++ b/src/securechannel/cryptogram.rs
@@ -1,5 +1,7 @@
 //! Authentication cryptograms (8-byte MACs) used for session verification
 
+use std::fmt;
+
 use clear_on_drop::clear::Clear;
 use constant_time_eq::constant_time_eq;
 
@@ -7,7 +9,7 @@ use constant_time_eq::constant_time_eq;
 pub const CRYPTOGRAM_SIZE: usize = 8;
 
 /// Authentication cryptograms used to verify sessions
-#[derive(Eq)]
+#[derive(Serialize, Deserialize, Eq)]
 pub struct Cryptogram([u8; CRYPTOGRAM_SIZE]);
 
 impl Cryptogram {
@@ -28,9 +30,15 @@ impl Cryptogram {
     }
 }
 
+impl fmt::Debug for Cryptogram {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "yubihsm_client::Cryptogram")
+    }
+}
+
 impl PartialEq for Cryptogram {
     fn eq(&self, other: &Cryptogram) -> bool {
-        constant_time_eq(&self.0[..], &other.0[..])
+        constant_time_eq(self.0.as_ref(), other.0.as_ref())
     }
 }
 

--- a/src/securechannel/kdf.rs
+++ b/src/securechannel/kdf.rs
@@ -43,7 +43,7 @@ pub fn derive(
     // Derivation context (i.e. challenges concatenated)
     derivation_data[16..].copy_from_slice(context.as_slice());
 
-    let mut mac = Cmac::<Aes128>::new_varkey(&mac_key[..]).unwrap();
+    let mut mac = Cmac::<Aes128>::new_varkey(mac_key.as_ref()).unwrap();
     mac.input(&derivation_data);
     output.copy_from_slice(&mac.result().code().as_slice()[..output_len]);
 }

--- a/src/securechannel/mac.rs
+++ b/src/securechannel/mac.rs
@@ -56,7 +56,7 @@ impl Mac {
 
 impl PartialEq for Mac {
     fn eq(&self, other: &Mac) -> bool {
-        constant_time_eq(&self.0[..], &other.0[..])
+        constant_time_eq(self.0.as_ref(), other.0.as_ref())
     }
 }
 

--- a/src/securechannel/response.rs
+++ b/src/securechannel/response.rs
@@ -168,10 +168,12 @@ impl ResponseMessage {
 
         result
     }
+}
 
+#[cfg(feature = "mockhsm")]
+impl Into<Vec<u8>> for ResponseMessage {
     /// Serialize this response, consuming it and producing a Vec<u8>
-    #[cfg(feature = "mockhsm")]
-    pub fn into_vec(mut self) -> Vec<u8> {
+    fn into(mut self) -> Vec<u8> {
         let mut result = Vec::with_capacity(3 + self.len());
         result.push(self.code.to_u8());
         result.write_u16::<BigEndian>(self.len() as u16).unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -82,7 +82,7 @@ fn integration_tests(session: &mut Session) {
 fn echo_test(session: &mut Session) {
     let message = b"Hello, world!";
     let response = session
-        .echo(&message[..])
+        .echo(message.as_ref())
         .unwrap_or_else(|err| panic!("error sending echo: {:?}", err));
 
     assert_eq!(&message[..], &response.message[..]);


### PR DESCRIPTION
This retrofits CreateSession into the new command framework.

It was previously using handrolled parsers because the command framework did not exist at the time it was originally implemented.