### PR TITLE
Upgrade to aesni 0.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,15 @@ version: 2
 jobs:
   build:
     docker:
-      - image: tarcieri/rust-yubihsm-sdk:latest
+      - image: tarcieri/rust-yubihsm-sdk:20180306
+    environment:
+      - RUSTFLAGS=-C target-feature=+aes
 
     steps:
       - checkout
       - restore_cache:
           # Bump this (and below) whenever the Docker image is updated
-          key: cache-20180228
+          key: cache-20180306
       - run:
           name: rustfmt
           command: |
@@ -32,7 +34,7 @@ jobs:
             cargo test --verbose --features=mockhsm
       - save_cache:
           # Bump this (and above) whenever the Docker image is updated
-          key: cache-20180228
+          key: cache-20180306
           paths:
             - "~/.cargo"
             - "./target"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories  = ["cryptography"]
 keywords    = ["cryptography", "encryption", "security"]
 
 [dependencies]
-aesni = "0.2"
+aesni = "0.3"
 bitflags = "1.0"
 block-modes = "0.1"
 byteorder = "1.2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
 FROM centos:7.4.1708
 
 # Install/update RPMs
-RUN yum update -y
-RUN yum groupinstall -y "Development Tools"
-RUN yum install -y curl openssl-devel python centos-release-scl
-
-# Install LLVM 4.0 from SCL
-RUN yum install -y llvm-toolset-7
+RUN yum update -y && \
+    yum groupinstall -y "Development Tools" && \
+    yum install -y curl openssl-devel python centos-release-scl && \
+    yum install -y llvm-toolset-7
 
 # Enable llvm-toolset-7 in the shell environment
 RUN bash -l -c "echo 'source scl_source enable llvm-toolset-7' > /etc/profile.d/llvm.sh"
@@ -21,7 +19,7 @@ RUN curl -O https://developers.yubico.com/YubiHSM2/Releases/yubihsm2-sdk-$YUBIHS
     rm -r yubihsm2-sdk
 
 ENV PATH "$PATH:/root/.cargo/bin"
-ENV RUST_NIGHTLY_VERSION "nightly-2018-02-27"
+ENV RUST_NIGHTLY_VERSION "nightly-2018-03-05"
 
 # Install Rust
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_NIGHTLY_VERSION
@@ -30,7 +28,7 @@ RUN bash -l -c "echo $(rustc --print sysroot)/lib >> /etc/ld.so.conf"
 RUN bash -l -c "echo /usr/local/lib64 >> /etc/ld.so.conf"
 RUN ldconfig
 
-ENV RUSTFMT_NIGHTLY_VERSION "0.3.8"
+ENV RUSTFMT_NIGHTLY_VERSION "0.4.0"
 RUN cargo install rustfmt-nightly --vers $RUSTFMT_NIGHTLY_VERSION --force
 
 ENV CLIPPY_VERSION "0.0.187"


### PR DESCRIPTION
This crate uses the (soon-to-be) stable `core::arch` API to invoke AES-NI rather than using inline assembly.

It requires the following RUSTFLAGS: `-C target-feature=+aes`