### PR TITLE
"cargo bench" for benchmarking Ed25519 signing speed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,13 +23,13 @@ jobs:
             cargo clippy --version
             cargo clippy --verbose --features=mockhsm
       - run:
-          name: build (nightly-2018-02-04)
+          name: build (nightly-2018-03-05)
           command: |
             rustc --version --verbose
             cargo --version --verbose
             cargo build --verbose
       - run:
-          name: test (nightly-2018-02-04)
+          name: test (nightly-2018-03-05)
           command: |
             cargo test --verbose --features=mockhsm
       - save_cache:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ sha2 = "0.6"
 tiny_http = { version = "0.5", optional = true }
 
 [features]
+bench = []
 default = []
 dalek = ["ed25519-dalek"]
 mockhsm = ["dalek", "tiny_http"]

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,0 +1,39 @@
+use test::Bencher;
+
+use {Algorithm, Capabilities, Connector, Domains, ObjectId, ObjectType};
+
+const YUBIHSM_ADDR: &str = "http://127.0.0.1:12345";
+const DEFAULT_AUTH_KEY_ID: ObjectId = 1;
+const DEFAULT_PASSWORD: &str = "password";
+const EXAMPLE_MESSAGE: &[u8] = b"";
+const TEST_KEY_ID: ObjectId = 100;
+const TEST_KEY_LABEL: &str = "yubihsm-rs benchmarking key";
+const TEST_CAPABILITIES: Capabilities = Capabilities::ASYMMETRIC_SIGN_EDDSA;
+const TEST_DOMAINS: Domains = Domains::DOMAIN_1;
+
+#[bench]
+fn ed25519_benchmark(b: &mut Bencher) {
+    let conn = Connector::open(YUBIHSM_ADDR).unwrap();
+    let mut session = conn.create_session_from_password(DEFAULT_AUTH_KEY_ID, DEFAULT_PASSWORD)
+        .unwrap();
+
+    // Delete the key in TEST_KEY_ID slot it exists
+    let _ = session.delete_object(TEST_KEY_ID, ObjectType::Asymmetric);
+
+    // Create a new key for testing
+    session
+        .generate_asymmetric_key(
+            TEST_KEY_ID,
+            TEST_KEY_LABEL.into(),
+            TEST_DOMAINS,
+            TEST_CAPABILITIES,
+            Algorithm::EC_ED25519,
+        )
+        .unwrap();
+
+    b.iter(|| {
+        session
+            .sign_data_eddsa(TEST_KEY_ID, EXAMPLE_MESSAGE)
+            .unwrap()
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![crate_name = "yubihsm_client"]
 #![crate_type = "lib"]
+#![cfg_attr(feature = "bench", feature(test))]
 #![deny(warnings, missing_docs, trivial_casts, trivial_numeric_casts)]
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 
@@ -27,6 +28,8 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate sha2;
+#[cfg(feature = "bench")]
+extern crate test;
 
 /// Custom error macros for using enums with descriptions for errors
 macro_rules! err {
@@ -48,11 +51,13 @@ macro_rules! fail {
 }
 
 pub mod algorithm;
+#[cfg(feature = "bench")]
+mod bench;
 pub mod capabilities;
 mod commands;
 pub mod connector;
 pub mod domains;
-#[cfg(any(feature = "mockhsm"))]
+#[cfg(feature = "mockhsm")]
 pub mod mockhsm;
 pub mod object;
 pub mod responses;

--- a/src/securechannel/mod.rs
+++ b/src/securechannel/mod.rs
@@ -45,7 +45,5 @@ pub use self::context::{Context, CONTEXT_SIZE};
 pub use self::cryptogram::{Cryptogram, CRYPTOGRAM_SIZE};
 pub use self::error::SecureChannelError;
 pub(crate) use self::mac::{Mac, MAC_SIZE};
-pub(crate) use self::response_message::ResponseMessage;
-#[cfg(feature = "mockhsm")]
-pub(crate) use self::response_message::ResponseCode;
+pub(crate) use self::response_message::{ResponseCode, ResponseMessage};
 pub use self::static_keys::StaticKeys;


### PR DESCRIPTION
Also needs the "bench" cargo feature, so a full invocation is:

    cargo bench --features=bench

This requires yubihsm-connector to be running, as it benchmarks signing performance live against the YubiHSM2.